### PR TITLE
remove height and width to provide font like behaviour.

### DIFF
--- a/src/font/typicons.css
+++ b/src/font/typicons.css
@@ -20,8 +20,6 @@
   speak: none;
   display: inline-block;
   text-decoration: inherit;
-  width: 1em;
-  height: 1em;
   font-size: 1em;
   text-align: center;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
Width and Height property make typicons difficult to use in many situation. It should be left to the user to choose those styling rules. This way typicons uses the correct space and can be embeded easily in text.
