### PR TITLE
Include SVG source files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,6 @@
   ],
   "ignore": [
     "**/.*",
-    "src/svg",
     "src/demo",
     "src/png-24px",
     "src/png-48px",


### PR DESCRIPTION
This will allow Bower to fetch SVG source files whenever you create a new release (required since Bower relies on tags).